### PR TITLE
[JENKINS-27464] Workflow plugin compatibility

### DIFF
--- a/com.ibm.team.build.hjplugin/pom.xml
+++ b/com.ibm.team.build.hjplugin/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
-		<version>1.480.3</version>
+		<version>1.580.1</version>
 	</parent>
 
 	<groupId>org.jenkins-ci.plugins</groupId>

--- a/com.ibm.team.build.hjplugin/src/main/java/com/ibm/team/build/internal/hjplugin/RTCBuildResultSetupTask.java
+++ b/com.ibm.team.build.hjplugin/src/main/java/com/ibm/team/build/internal/hjplugin/RTCBuildResultSetupTask.java
@@ -36,7 +36,7 @@ import com.ibm.team.build.internal.hjplugin.RTCFacadeFactory.RTCFacadeWrapper;
  * to this task since an exception (of any kind) in that will prevent lifecycle
  * info from being linked to the build.
  */
-public class RTCBuildResultSetupTask extends RTCTask implements FileCallable<BuildResultInfo> {
+public class RTCBuildResultSetupTask extends RTCTask<BuildResultInfo> implements FileCallable<BuildResultInfo> {
 
     private static final Logger LOGGER = Logger.getLogger(RTCBuildResultSetupTask.class.getName());
 

--- a/com.ibm.team.build.hjplugin/src/main/java/com/ibm/team/build/internal/hjplugin/RTCBuildResultSetupTask.java
+++ b/com.ibm.team.build.hjplugin/src/main/java/com/ibm/team/build/internal/hjplugin/RTCBuildResultSetupTask.java
@@ -12,7 +12,6 @@
 package com.ibm.team.build.internal.hjplugin;
 
 import hudson.AbortException;
-import hudson.FilePath.FileCallable;
 import hudson.model.TaskListener;
 import hudson.remoting.VirtualChannel;
 import hudson.util.Secret;
@@ -36,7 +35,7 @@ import com.ibm.team.build.internal.hjplugin.RTCFacadeFactory.RTCFacadeWrapper;
  * to this task since an exception (of any kind) in that will prevent lifecycle
  * info from being linked to the build.
  */
-public class RTCBuildResultSetupTask extends RTCTask<BuildResultInfo> implements FileCallable<BuildResultInfo> {
+public class RTCBuildResultSetupTask extends RTCTask<BuildResultInfo> {
 
     private static final Logger LOGGER = Logger.getLogger(RTCBuildResultSetupTask.class.getName());
 

--- a/com.ibm.team.build.hjplugin/src/main/java/com/ibm/team/build/internal/hjplugin/RTCBuildToolInstallation.java
+++ b/com.ibm.team.build.hjplugin/src/main/java/com/ibm/team/build/internal/hjplugin/RTCBuildToolInstallation.java
@@ -187,9 +187,7 @@ public class RTCBuildToolInstallation extends ToolInstallation implements NodeSp
         /**
          * Checks if the path to the build toolkit is valid
          */
-        public FormValidation doCheckHome(@QueryParameter File value)
-            throws IOException, ServletException {
-
+        public FormValidation doCheckHome(@QueryParameter File value)  {
             return validateBuildToolkit(false, value);
         }
         

--- a/com.ibm.team.build.hjplugin/src/main/java/com/ibm/team/build/internal/hjplugin/RTCChangeLogParser.java
+++ b/com.ibm.team.build.hjplugin/src/main/java/com/ibm/team/build/internal/hjplugin/RTCChangeLogParser.java
@@ -13,28 +13,31 @@ package com.ibm.team.build.internal.hjplugin;
 
 import hudson.model.Run;
 import hudson.scm.ChangeLogParser;
-import hudson.scm.ChangeLogSet;
 import hudson.scm.RepositoryBrowser;
+import hudson.scm.ChangeLogSet;
 import hudson.scm.ChangeLogSet.Entry;
 import hudson.util.Digester2;
 
 import java.io.File;
-import java.io.FileReader;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.io.Reader;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.xml.sax.SAXException;
 
+import com.google.common.base.Charsets;
+
 public class RTCChangeLogParser extends ChangeLogParser {
     private static final Logger LOGGER = Logger.getLogger(RTCChangeLogParser.class.getName());
-	
+
 	@Override
 	public ChangeLogSet<? extends Entry> parse(Run build,
 			RepositoryBrowser<?> browser, File changeLogFile)
 			throws IOException, SAXException {
-		FileReader changeLogReader = new FileReader(changeLogFile);
+		Reader changeLogReader = new InputStreamReader(new FileInputStream(changeLogFile), Charsets.UTF_8);
 		try {
 			return parse(build, browser, changeLogReader);
 		} finally {

--- a/com.ibm.team.build.hjplugin/src/main/java/com/ibm/team/build/internal/hjplugin/RTCChangeLogParser.java
+++ b/com.ibm.team.build.hjplugin/src/main/java/com/ibm/team/build/internal/hjplugin/RTCChangeLogParser.java
@@ -11,20 +11,17 @@
 
 package com.ibm.team.build.internal.hjplugin;
 
-import hudson.model.AbstractBuild;
+import hudson.model.Run;
 import hudson.scm.ChangeLogParser;
 import hudson.scm.ChangeLogSet;
+import hudson.scm.RepositoryBrowser;
 import hudson.scm.ChangeLogSet.Entry;
 import hudson.util.Digester2;
 
 import java.io.File;
-import java.io.FileInputStream;
+import java.io.FileReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.io.Reader;
-import java.nio.charset.Charset;
-import java.nio.charset.CharsetDecoder;
-import java.nio.charset.CodingErrorAction;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -32,87 +29,86 @@ import org.xml.sax.SAXException;
 
 public class RTCChangeLogParser extends ChangeLogParser {
     private static final Logger LOGGER = Logger.getLogger(RTCChangeLogParser.class.getName());
-
+	
 	@Override
-	public ChangeLogSet<? extends Entry> parse(AbstractBuild build,
-			File changelogFile) throws IOException, SAXException {
-		FileInputStream inputStream = new FileInputStream(changelogFile);
-        CharsetDecoder decoder = Charset.forName("UTF-8").newDecoder().onMalformedInput(CodingErrorAction.REPORT).onUnmappableCharacter(CodingErrorAction.REPORT); //$NON-NLS-1$
-		Reader reader = new InputStreamReader(inputStream, decoder);
-		return parse(build, reader);
+	public ChangeLogSet<? extends Entry> parse(Run build,
+			RepositoryBrowser<?> browser, File changeLogFile)
+			throws IOException, SAXException {
+		FileReader changeLogReader = new FileReader(changeLogFile);
+		try {
+			return parse(build, browser, changeLogReader);
+		} finally {
+			changeLogReader.close();
+		}
 	}
 	
-	public ChangeLogSet<? extends Entry> parse(AbstractBuild build,
-			Reader changelogReader) throws IOException, SAXException {
+	public ChangeLogSet<? extends Entry> parse(Run build,
+			RepositoryBrowser<?> browser, Reader changeLogReader)
+			throws IOException, SAXException {
 
-		try {
-			RTCChangeLogSet result = new RTCChangeLogSet(build);
-			Digester2 digester = getDigester();
-			digester.push(result);
-	
-			digester.addSetProperties("changelog"); //$NON-NLS-1$
-			digester.addBeanPropertySetter("*/baselineSetItemId"); //$NON-NLS-1$
-			digester.addBeanPropertySetter("*/baselineSetName"); //$NON-NLS-1$
-			digester.addBeanPropertySetter("*/workspaceItemId"); //$NON-NLS-1$
-			digester.addBeanPropertySetter("*/isPersonalBuild"); //$NON-NLS-1$
-			
-			// When digester reads a {{<changeset>}} node it will create a {{RTCChangeLogChangeSetEntry}} object
-			digester.addObjectCreate("*/changeset", RTCChangeLogChangeSetEntry.class); //$NON-NLS-1$
-			// Reads all attributes in the {{<changeset>}} node and uses setter method in class to set the values
-			digester.addSetProperties("*/changeset"); //$NON-NLS-1$
-			// Reads the child node {{<action>}} and uses {{RTCChangeLogChangeSetEntry.setAction()}} to set the value
-			digester.addBeanPropertySetter("*/changeset/action"); //$NON-NLS-1$
-			digester.addBeanPropertySetter("*/changeset/changeSetItemId"); //$NON-NLS-1$
-			digester.addBeanPropertySetter("*/changeset/componentItemId"); //$NON-NLS-1$
-			digester.addBeanPropertySetter("*/changeset/componentName"); //$NON-NLS-1$
-			digester.addBeanPropertySetter("*/changeset/owner"); //$NON-NLS-1$
-			digester.addBeanPropertySetter("*/changeset/comment"); //$NON-NLS-1$
-			digester.addBeanPropertySetter("*/changeset/additionalChanges"); //$NON-NLS-1$
-			digester.addBeanPropertySetter("*/changeset/date"); //$NON-NLS-1$
-			// The digested node/changeset is added to the change log through {{RTCChangeLogSet.add()}}
-			digester.addSetNext("*/changeset", "add"); //$NON-NLS-1$ //$NON-NLS-2$
-	
-			// When digester reads a {{<changes>}} child node of {{<changeset}} it will create a {{RTCChangeLogChangeSetEntry.ChangeDesc}} object
-			digester.addObjectCreate("*/changeset/changes/change", RTCChangeLogChangeSetEntry.ChangeDesc.class); //$NON-NLS-1$
-			digester.addSetProperties("*/changeset/changes/change"); //$NON-NLS-1$
-			digester.addBeanPropertySetter("*/changeset/changes/change/kind"); //$NON-NLS-1$
-			digester.addBeanPropertySetter("*/changeset/changes/change/name"); //$NON-NLS-1$
-			digester.addBeanPropertySetter("*/changeset/changes/change/itemType"); //$NON-NLS-1$
-			digester.addBeanPropertySetter("*/changeset/changes/change/itemId"); //$NON-NLS-1$
-			digester.addBeanPropertySetter("*/changeset/changes/change/stateId"); //$NON-NLS-1$
-			// The digested node/change is added to the change set through {{RTCChangeLogChangeSetEntry.addChange()}}
-			digester.addSetNext("*/changeset/changes/change", "addChange"); //$NON-NLS-1$ //$NON-NLS-2$
-	
-			// When digester reads a {{<workitems>}} child node of {{<changeset}} it will create a {{RTCChangeLogChangeSetEntry.WorkItemDesc}} object
-			digester.addObjectCreate("*/changeset/workItems/workItem", RTCChangeLogChangeSetEntry.WorkItemDesc.class); //$NON-NLS-1$
-			digester.addSetProperties("*/changeset/workItems/workItem"); //$NON-NLS-1$
-			digester.addBeanPropertySetter("*/changeset/workItems/workItem/number"); //$NON-NLS-1$
-			digester.addBeanPropertySetter("*/changeset/workItems/workItem/summary"); //$NON-NLS-1$
-			// The digested node/workItem is added to the change set through {{RTCChangeLogChangeSetEntry.addWorkItem()}}
-			digester.addSetNext("*/changeset/workItems/workItem", "addWorkItem"); //$NON-NLS-1$ //$NON-NLS-2$
-	
-			// components that were added/dropped
-			// When digester reads a {{<component>}} node it will create a {{RTCChangeLogComponentEntry}} object
-			digester.addObjectCreate("*/component", RTCChangeLogComponentEntry.class); //$NON-NLS-1$
-			// Reads all attributes in the {{<component>}} node and uses setter method in class to set the values
-			digester.addSetProperties("*/component"); //$NON-NLS-1$
-			// Reads the child node {{<action>}} and uses {{RTCChangeLogComponentEntry.setAction()}} to set the value
-			digester.addBeanPropertySetter("*/component/action"); //$NON-NLS-1$
-			// Reads the child node {{<name>}} and uses {{RTCChangeLogComponentEntry.setName()}} to set the value
-			digester.addBeanPropertySetter("*/component/name"); //$NON-NLS-1$
-			// Reads the child node {{<uuid>}} and uses {{RTCChangeLogComponentEntry.setUuid()}} to set the value
-			digester.addBeanPropertySetter("*/component/uuid"); //$NON-NLS-1$
-			// The digested node/change set is added to the list through {{RTCChangeLogSet.add()}}
-			digester.addSetNext("*/component", "add"); //$NON-NLS-1$ //$NON-NLS-2$
-	
-	
-			// Do the actual parsing
-			digester.parse(changelogReader);
-			return result;
+		RTCChangeLogSet result = new RTCChangeLogSet(build, browser);
+		Digester2 digester = getDigester();
+		digester.push(result);
 
-		} finally {
-			changelogReader.close();
-		}
+		digester.addSetProperties("changelog"); //$NON-NLS-1$
+		digester.addBeanPropertySetter("*/baselineSetItemId"); //$NON-NLS-1$
+		digester.addBeanPropertySetter("*/baselineSetName"); //$NON-NLS-1$
+		digester.addBeanPropertySetter("*/workspaceItemId"); //$NON-NLS-1$
+		digester.addBeanPropertySetter("*/isPersonalBuild"); //$NON-NLS-1$
+		
+		// When digester reads a {{<changeset>}} node it will create a {{RTCChangeLogChangeSetEntry}} object
+		digester.addObjectCreate("*/changeset", RTCChangeLogChangeSetEntry.class); //$NON-NLS-1$
+		// Reads all attributes in the {{<changeset>}} node and uses setter method in class to set the values
+		digester.addSetProperties("*/changeset"); //$NON-NLS-1$
+		// Reads the child node {{<action>}} and uses {{RTCChangeLogChangeSetEntry.setAction()}} to set the value
+		digester.addBeanPropertySetter("*/changeset/action"); //$NON-NLS-1$
+		digester.addBeanPropertySetter("*/changeset/changeSetItemId"); //$NON-NLS-1$
+		digester.addBeanPropertySetter("*/changeset/componentItemId"); //$NON-NLS-1$
+		digester.addBeanPropertySetter("*/changeset/componentName"); //$NON-NLS-1$
+		digester.addBeanPropertySetter("*/changeset/owner"); //$NON-NLS-1$
+		digester.addBeanPropertySetter("*/changeset/comment"); //$NON-NLS-1$
+		digester.addBeanPropertySetter("*/changeset/additionalChanges"); //$NON-NLS-1$
+		digester.addBeanPropertySetter("*/changeset/date"); //$NON-NLS-1$
+		// The digested node/changeset is added to the change log through {{RTCChangeLogSet.add()}}
+		digester.addSetNext("*/changeset", "add"); //$NON-NLS-1$ //$NON-NLS-2$
+
+		// When digester reads a {{<changes>}} child node of {{<changeset}} it will create a {{RTCChangeLogChangeSetEntry.ChangeDesc}} object
+		digester.addObjectCreate("*/changeset/changes/change", RTCChangeLogChangeSetEntry.ChangeDesc.class); //$NON-NLS-1$
+		digester.addSetProperties("*/changeset/changes/change"); //$NON-NLS-1$
+		digester.addBeanPropertySetter("*/changeset/changes/change/kind"); //$NON-NLS-1$
+		digester.addBeanPropertySetter("*/changeset/changes/change/name"); //$NON-NLS-1$
+		digester.addBeanPropertySetter("*/changeset/changes/change/itemType"); //$NON-NLS-1$
+		digester.addBeanPropertySetter("*/changeset/changes/change/itemId"); //$NON-NLS-1$
+		digester.addBeanPropertySetter("*/changeset/changes/change/stateId"); //$NON-NLS-1$
+		// The digested node/change is added to the change set through {{RTCChangeLogChangeSetEntry.addChange()}}
+		digester.addSetNext("*/changeset/changes/change", "addChange"); //$NON-NLS-1$ //$NON-NLS-2$
+
+		// When digester reads a {{<workitems>}} child node of {{<changeset}} it will create a {{RTCChangeLogChangeSetEntry.WorkItemDesc}} object
+		digester.addObjectCreate("*/changeset/workItems/workItem", RTCChangeLogChangeSetEntry.WorkItemDesc.class); //$NON-NLS-1$
+		digester.addSetProperties("*/changeset/workItems/workItem"); //$NON-NLS-1$
+		digester.addBeanPropertySetter("*/changeset/workItems/workItem/number"); //$NON-NLS-1$
+		digester.addBeanPropertySetter("*/changeset/workItems/workItem/summary"); //$NON-NLS-1$
+		// The digested node/workItem is added to the change set through {{RTCChangeLogChangeSetEntry.addWorkItem()}}
+		digester.addSetNext("*/changeset/workItems/workItem", "addWorkItem"); //$NON-NLS-1$ //$NON-NLS-2$
+
+		// components that were added/dropped
+		// When digester reads a {{<component>}} node it will create a {{RTCChangeLogComponentEntry}} object
+		digester.addObjectCreate("*/component", RTCChangeLogComponentEntry.class); //$NON-NLS-1$
+		// Reads all attributes in the {{<component>}} node and uses setter method in class to set the values
+		digester.addSetProperties("*/component"); //$NON-NLS-1$
+		// Reads the child node {{<action>}} and uses {{RTCChangeLogComponentEntry.setAction()}} to set the value
+		digester.addBeanPropertySetter("*/component/action"); //$NON-NLS-1$
+		// Reads the child node {{<name>}} and uses {{RTCChangeLogComponentEntry.setName()}} to set the value
+		digester.addBeanPropertySetter("*/component/name"); //$NON-NLS-1$
+		// Reads the child node {{<uuid>}} and uses {{RTCChangeLogComponentEntry.setUuid()}} to set the value
+		digester.addBeanPropertySetter("*/component/uuid"); //$NON-NLS-1$
+		// The digested node/change set is added to the list through {{RTCChangeLogSet.add()}}
+		digester.addSetNext("*/component", "add"); //$NON-NLS-1$ //$NON-NLS-2$
+
+
+		// Do the actual parsing
+		digester.parse(changeLogReader);
+		return result;
 	}
 	
 	private Digester2 getDigester() {

--- a/com.ibm.team.build.hjplugin/src/main/java/com/ibm/team/build/internal/hjplugin/RTCChangeLogSet.java
+++ b/com.ibm.team.build.hjplugin/src/main/java/com/ibm/team/build/internal/hjplugin/RTCChangeLogSet.java
@@ -12,7 +12,10 @@
 package com.ibm.team.build.internal.hjplugin;
 
 import hudson.model.AbstractBuild;
+import hudson.model.Job;
+import hudson.model.Run;
 import hudson.scm.ChangeLogSet;
+import hudson.scm.RepositoryBrowser;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -106,8 +109,8 @@ public class RTCChangeLogSet extends ChangeLogSet<RTCChangeLogSetEntry> {
 	private transient boolean componentChangesSorted;
 	private transient List<RTCChangeLogSetEntry> allChanges;
 	
-	public RTCChangeLogSet(AbstractBuild<?, ?> build) {
-		super(build);
+	public RTCChangeLogSet(Run<?, ?> build, RepositoryBrowser<?> browser) {
+		super(build, browser);
 		this.componentChanges = new ArrayList<RTCChangeLogComponentEntry>(0);
 		this.affectedComponents = new TreeSet<ComponentDescriptor>();
 		this.changesAccepted = new HashMap<String, List<RTCChangeLogChangeSetEntry>>();

--- a/com.ibm.team.build.hjplugin/src/main/java/com/ibm/team/build/internal/hjplugin/RTCCheckoutTask.java
+++ b/com.ibm.team.build.hjplugin/src/main/java/com/ibm/team/build/internal/hjplugin/RTCCheckoutTask.java
@@ -29,7 +29,7 @@ import java.util.logging.Logger;
 
 import com.ibm.team.build.internal.hjplugin.RTCFacadeFactory.RTCFacadeWrapper;
 
-public class RTCCheckoutTask extends RTCTask implements FileCallable<Map<String, String>> {
+public class RTCCheckoutTask extends RTCTask<Map<String, String>> implements FileCallable<Map<String, String>> {
     private static final Logger LOGGER = Logger.getLogger(RTCCheckoutTask.class.getName());
 
 	private String buildToolkit;

--- a/com.ibm.team.build.hjplugin/src/main/java/com/ibm/team/build/internal/hjplugin/RTCCheckoutTask.java
+++ b/com.ibm.team.build.hjplugin/src/main/java/com/ibm/team/build/internal/hjplugin/RTCCheckoutTask.java
@@ -12,7 +12,6 @@
 package com.ibm.team.build.internal.hjplugin;
 
 import hudson.AbortException;
-import hudson.FilePath.FileCallable;
 import hudson.model.TaskListener;
 import hudson.remoting.RemoteOutputStream;
 import hudson.remoting.VirtualChannel;
@@ -29,7 +28,7 @@ import java.util.logging.Logger;
 
 import com.ibm.team.build.internal.hjplugin.RTCFacadeFactory.RTCFacadeWrapper;
 
-public class RTCCheckoutTask extends RTCTask<Map<String, String>> implements FileCallable<Map<String, String>> {
+public class RTCCheckoutTask extends RTCTask<Map<String, String>> {
     private static final Logger LOGGER = Logger.getLogger(RTCCheckoutTask.class.getName());
 
 	private String buildToolkit;

--- a/com.ibm.team.build.hjplugin/src/main/java/com/ibm/team/build/internal/hjplugin/RTCLoginInfo.java
+++ b/com.ibm.team.build.hjplugin/src/main/java/com/ibm/team/build/internal/hjplugin/RTCLoginInfo.java
@@ -12,6 +12,7 @@ package com.ibm.team.build.internal.hjplugin;
 
 import hudson.Util;
 import hudson.model.AbstractProject;
+import hudson.model.Job;
 import hudson.security.ACL;
 import hudson.util.FormValidation;
 
@@ -42,7 +43,7 @@ public class RTCLoginInfo {
 	/**
 	 * Figure out the info needed to log into RTC based on a variety of ways to authenticate
 	 * It is expected that supplied values have been validated to some degree
-	 * @param project The project to be built (hence credentials needed for) may be
+	 * @param job The project to be built (hence credentials needed for) may be
 	 * <code>null</code> when dealing with the global case
 	 * @param buildToolkitPath The path of the build toolkit. Could be <code>null</code>
 	 * if not using a password file
@@ -58,7 +59,7 @@ public class RTCLoginInfo {
 	 * @param timeout The time out to use (in seconds). Required
 	 * @throws Exception When something goes wrong determining the credentials.
 	 */
-	public RTCLoginInfo(AbstractProject<?, ?> project, String buildToolkitPath,
+	public RTCLoginInfo(Job<?, ?> job, String buildToolkitPath,
 			String serverUri, String userId, String password,
 			String passwordFile, String credentialsId, int timeout) throws InvalidCredentialsException {
 		credentialsId = Util.fixEmptyAndTrim(credentialsId);
@@ -72,10 +73,10 @@ public class RTCLoginInfo {
 				LOGGER.finer("Looking up credentials for " +  //$NON-NLS-1$
 						"credentialId=\"" + credentialsId + //$NON-NLS-1$
 						"\" serverURI=\"" + serverUri +  //$NON-NLS-1$
-						"\" project=" + (project == null ? "null" : "\"" + project.getName() + "\"")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ $NON-NLS-2$ $NON-NLS-3$ $NON-NLS-4$ 
+						"\" project=" + (job == null ? "null" : "\"" + job.getName() + "\"")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ $NON-NLS-2$ $NON-NLS-3$ $NON-NLS-4$ 
 			}
 
-			List<StandardUsernamePasswordCredentials> allMatchingCredentials = CredentialsProvider.lookupCredentials(StandardUsernamePasswordCredentials.class, project, ACL.SYSTEM,
+			List<StandardUsernamePasswordCredentials> allMatchingCredentials = CredentialsProvider.lookupCredentials(StandardUsernamePasswordCredentials.class, job, ACL.SYSTEM,
 							URIRequirementBuilder.fromUri(serverUri).build());
 			StandardUsernamePasswordCredentials credentials = CredentialsMatchers.firstOrNull(allMatchingCredentials, 
 							CredentialsMatchers.withId(credentialsId));

--- a/com.ibm.team.build.hjplugin/src/main/java/com/ibm/team/build/internal/hjplugin/RTCScm.java
+++ b/com.ibm.team.build.hjplugin/src/main/java/com/ibm/team/build/internal/hjplugin/RTCScm.java
@@ -16,8 +16,6 @@ import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.Util;
-import hudson.FilePath.FileCallable;
-import hudson.model.BuildListener;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.model.AbstractBuild;

--- a/com.ibm.team.build.hjplugin/src/main/java/com/ibm/team/build/internal/hjplugin/RTCScm.java
+++ b/com.ibm.team.build.hjplugin/src/main/java/com/ibm/team/build/internal/hjplugin/RTCScm.java
@@ -16,12 +16,16 @@ import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.Util;
+import hudson.FilePath.FileCallable;
 import hudson.model.BuildListener;
+import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.CauseAction;
+import hudson.model.Computer;
 import hudson.model.Hudson;
+import hudson.model.Job;
 import hudson.model.Node;
 import hudson.remoting.Channel;
 import hudson.remoting.RemoteOutputStream;
@@ -41,6 +45,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintWriter;
+import java.io.Serializable;
 import java.lang.reflect.InvocationTargetException;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -48,6 +53,7 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 
 import org.jvnet.localizer.LocaleProvider;
@@ -109,7 +115,8 @@ public class RTCScm extends SCM {
 	 * Structure that represents the radio button selection for build workspace/definition
 	 * choice in config.jelly (job configuration) 
 	 */
-	public static class BuildType {
+	public static class BuildType implements Serializable {
+		private static final long serialVersionUID = 1L;
 		public String type;
 		public String buildDefinition;
 		public String buildWorkspace;
@@ -951,12 +958,11 @@ public class RTCScm extends SCM {
 		// So for now we don't return a special revision state
 		return SCMRevisionState.NONE;
 	}
-
+	
 	@Override
-	public boolean checkout(AbstractBuild<?, ?> build, Launcher arg1,
-			FilePath workspacePath, BuildListener listener, File changeLogFile) throws IOException,
-			InterruptedException {
-		
+	public void checkout(Run<?, ?> build, Launcher launcher,
+			FilePath workspacePath, TaskListener listener, File changeLogFile,
+			SCMRevisionState baseline) throws IOException, InterruptedException {
 		listener.getLogger().println(Messages.RTCScm_checkout_started());
 
 		String label = getLabel(build);
@@ -978,12 +984,15 @@ public class RTCScm extends SCM {
 		RTCBuildResultAction buildResultAction;
 		
 		try {
+			Node node = workspaceToNode(workspacePath);
+			Job<?, ?> job = build.getParent();
+
 			localBuildToolkit = getDescriptor().getMasterBuildToolkit(getBuildTool(), listener);
-			nodeBuildToolkit = getDescriptor().getBuildToolkit(getBuildTool(), build.getBuiltOn(), listener);
-			RTCLoginInfo loginInfo = getLoginInfo(build.getProject(), localBuildToolkit);
+			nodeBuildToolkit = getDescriptor().getBuildToolkit(getBuildTool(), node, listener);
+			RTCLoginInfo loginInfo = getLoginInfo(job, localBuildToolkit);
 			
 			if (LOGGER.isLoggable(Level.FINER)) {
-				LOGGER.finer("checkout : " + build.getProject().getName() + " " + build.getDisplayName() + " " + build.getBuiltOnStr() + //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+				LOGGER.finer("checkout : " + job.getName() + " " + build.getDisplayName() + " " + node.getNodeName() + //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 						" Load directory=\"" + workspacePath.getRemote() + "\"" +  //$NON-NLS-1$ //$NON-NLS-2$
 						" Build tool=\"" + getBuildTool() + "\"" + //$NON-NLS-1$ //$NON-NLS-2$
 						" Local Build toolkit=\"" + localBuildToolkit + "\"" + //$NON-NLS-1$ //$NON-NLS-2$
@@ -1009,7 +1018,7 @@ public class RTCScm extends SCM {
 				sendJarsToSlave(workspacePath);
 			}
 
-			RTCBuildResultSetupTask buildResultSetupTask = new RTCBuildResultSetupTask(build.getProject().getName() + " " + build.getDisplayName() + " " + build.getBuiltOnStr(), //$NON-NLS-1$ //$NON-NLS-2$
+			RTCBuildResultSetupTask buildResultSetupTask = new RTCBuildResultSetupTask(job.getName() + " " + build.getDisplayName() + " " + node.getNodeName(), //$NON-NLS-1$ //$NON-NLS-2$
 					nodeBuildToolkit,
 					loginInfo.getServerUri(), loginInfo.getUserId(), loginInfo.getPassword(), loginInfo.getTimeout(),
 					useBuildDefinitionInBuild, buildDefinition, buildResultUUID,
@@ -1021,7 +1030,7 @@ public class RTCScm extends SCM {
 			}
 
 			if (LOGGER.isLoggable(Level.FINER)) {
-				LOGGER.finer("checkout : " + build.getProject().getName() + " " + build.getDisplayName() + " " + build.getBuiltOnStr() + //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+				LOGGER.finer("checkout : " + job.getName() + " " + build.getDisplayName() + " " + node.getNodeName() + //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 						" initial buildResultUUID=\"" + buildResultUUID + "\"" +  //$NON-NLS-1$ //$NON-NLS-2$
 						" current buildResultUUID=\"" + buildResultInfo.getBuildResultUUID() + "\"" + //$NON-NLS-1$ //$NON-NLS-2$
 						" scheduled=\"" + buildResultInfo.isScheduled() + "\"" + //$NON-NLS-1$ //$NON-NLS-2$
@@ -1055,7 +1064,7 @@ public class RTCScm extends SCM {
 			RemoteOutputStream changeLog = new RemoteOutputStream(changeLogStream);
 			
 			RTCCheckoutTask checkout = new RTCCheckoutTask(
-					build.getProject().getName() + " " + build.getDisplayName() + " " + build.getBuiltOnStr(), //$NON-NLS-1$ //$NON-NLS-2$
+					job.getName() + " " + build.getDisplayName() + " " + node.getNodeName(), //$NON-NLS-1$ //$NON-NLS-2$
 					nodeBuildToolkit, loginInfo.getServerUri(), loginInfo.getUserId(), loginInfo.getPassword(), loginInfo.getTimeout(), buildResultUUID,
 					buildWorkspace,
 					label,
@@ -1068,7 +1077,7 @@ public class RTCScm extends SCM {
 				if (rootUrl != null) {
 					rootUrl = Util.encode(rootUrl);
 				}
-				String projectUrl = build.getProject().getUrl();
+				String projectUrl = job.getUrl();
 				if (projectUrl != null) {
 					projectUrl = Util.encode(projectUrl);
 				}
@@ -1103,8 +1112,13 @@ public class RTCScm extends SCM {
     		throw new AbortException(Messages.RTCScm_checkout_failure4(e.getMessage()));
     	}
 
-
-		return true;
+	}
+	
+	@Override
+	public SCMRevisionState calcRevisionsFromBuild(Run<?, ?> build,
+			FilePath workspace, Launcher launcher, TaskListener listener)
+			throws IOException, InterruptedException {
+		return SCMRevisionState.NONE;
 	}
 
 	private void sendJarsToSlave(FilePath workspacePath)
@@ -1121,7 +1135,7 @@ public class RTCScm extends SCM {
 		}
 	}
 
-	private String getLabel(AbstractBuild<?, ?> build) {
+	private String getLabel(Run<?, ?> build) {
 		// TODO if we have a build definition & build result id we should probably
 		// follow a similar algorithm to RTC?
 		// In the simple plugin case, generate the name from the project and the build
@@ -1225,8 +1239,8 @@ public class RTCScm extends SCM {
 		return overrideGlobal;
 	}
 	
-	public RTCLoginInfo getLoginInfo(AbstractProject project, String toolkit) throws InvalidCredentialsException {
-		return new RTCLoginInfo(project, toolkit, getServerURI(), getUserId(), getPassword(), getPasswordFile(), getCredentialsId(), getTimeout());
+	public RTCLoginInfo getLoginInfo(Job<?, ?> job, String toolkit) throws InvalidCredentialsException {
+		return new RTCLoginInfo(job, toolkit, getServerURI(), getUserId(), getPassword(), getPasswordFile(), getCredentialsId(), getTimeout());
 	}
 	
 	public String getBuildTool() {
@@ -1366,4 +1380,20 @@ public class RTCScm extends SCM {
 	public String getType() {
 		return super.getType();
 	}
+
+	// lifted from hudson.plugins.git.GitSCM
+    private static Node workspaceToNode(FilePath workspace) {
+        Jenkins j = Jenkins.getInstance();
+        if (workspace != null && workspace.isRemote()) {
+            for (Computer c : j.getComputers()) {
+                if (c.getChannel() == workspace.getChannel()) {
+                    Node n = c.getNode();
+                    if (n != null) {
+                        return n;
+                    }
+                }
+            }
+        }
+        return j;
+    }
 }

--- a/com.ibm.team.build.hjplugin/src/main/java/com/ibm/team/build/internal/hjplugin/RTCScm.java
+++ b/com.ibm.team.build.hjplugin/src/main/java/com/ibm/team/build/internal/hjplugin/RTCScm.java
@@ -956,7 +956,7 @@ public class RTCScm extends SCM {
 		// So for now we don't return a special revision state
 		return SCMRevisionState.NONE;
 	}
-	
+
 	@Override
 	public void checkout(Run<?, ?> build, Launcher launcher,
 			FilePath workspacePath, TaskListener listener, File changeLogFile,
@@ -982,7 +982,7 @@ public class RTCScm extends SCM {
 		RTCBuildResultAction buildResultAction;
 		
 		try {
-			Node node = workspaceToNode(workspacePath);
+			Node node = workspacePath.toComputer().getNode();
 			Job<?, ?> job = build.getParent();
 
 			localBuildToolkit = getDescriptor().getMasterBuildToolkit(getBuildTool(), listener);
@@ -1379,19 +1379,4 @@ public class RTCScm extends SCM {
 		return super.getType();
 	}
 
-	// lifted from hudson.plugins.git.GitSCM
-    private static Node workspaceToNode(FilePath workspace) {
-        Jenkins j = Jenkins.getInstance();
-        if (workspace != null && workspace.isRemote()) {
-            for (Computer c : j.getComputers()) {
-                if (c.getChannel() == workspace.getChannel()) {
-                    Node n = c.getNode();
-                    if (n != null) {
-                        return n;
-                    }
-                }
-            }
-        }
-        return j;
-    }
 }

--- a/com.ibm.team.build.hjplugin/src/main/java/com/ibm/team/build/internal/hjplugin/RTCTask.java
+++ b/com.ibm.team.build.hjplugin/src/main/java/com/ibm/team/build/internal/hjplugin/RTCTask.java
@@ -12,7 +12,6 @@ package com.ibm.team.build.internal.hjplugin;
 
 import hudson.model.TaskListener;
 
-import java.io.Serializable;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -21,7 +20,7 @@ import jenkins.MasterToSlaveFileCallable;
 /**
  * Base class for tasks running on slaves. Handles common work like debug logging
  */
-public abstract class RTCTask<T> extends MasterToSlaveFileCallable<T> implements Serializable {
+public abstract class RTCTask<T> extends MasterToSlaveFileCallable<T> {
 
 	private static final long serialVersionUID = 1L;
 	

--- a/com.ibm.team.build.hjplugin/src/main/java/com/ibm/team/build/internal/hjplugin/RTCTask.java
+++ b/com.ibm.team.build.hjplugin/src/main/java/com/ibm/team/build/internal/hjplugin/RTCTask.java
@@ -10,17 +10,18 @@
  *******************************************************************************/
 package com.ibm.team.build.internal.hjplugin;
 
-import hudson.model.BuildListener;
 import hudson.model.TaskListener;
 
 import java.io.Serializable;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import jenkins.MasterToSlaveFileCallable;
+
 /**
  * Base class for tasks running on slaves. Handles common work like debug logging
  */
-public abstract class RTCTask implements Serializable {
+public abstract class RTCTask<T> extends MasterToSlaveFileCallable<T> implements Serializable {
 
 	private static final long serialVersionUID = 1L;
 	

--- a/com.ibm.team.build.hjplugin/src/test/java/com/ibm/team/build/internal/hjplugin/tests/BuildConfigurationIT.java
+++ b/com.ibm.team.build.hjplugin/src/test/java/com/ibm/team/build/internal/hjplugin/tests/BuildConfigurationIT.java
@@ -141,7 +141,7 @@ public class BuildConfigurationIT extends HudsonTestCase {
 				
 	    		RTCChangeLogParser parser = new RTCChangeLogParser();
 	    		FileReader changeLogReader = new FileReader(changeLogFile);
-	    		RTCChangeLogSet result = (RTCChangeLogSet) parser.parse(null, changeLogReader);
+	    		RTCChangeLogSet result = (RTCChangeLogSet) parser.parse(null, null, changeLogReader);
 	    		
 	    		// verify the result
 	    		int changeCount = result.getComponentChangeCount() +
@@ -430,7 +430,7 @@ public class BuildConfigurationIT extends HudsonTestCase {
 				
 	    		RTCChangeLogParser parser = new RTCChangeLogParser();
 	    		FileReader changeLogReader = new FileReader(changeLogFile);
-	    		RTCChangeLogSet result = (RTCChangeLogSet) parser.parse(null, changeLogReader);
+	    		RTCChangeLogSet result = (RTCChangeLogSet) parser.parse(null, null, changeLogReader);
 	    		
 	    		// verify the result
 	    		Assert.assertTrue(result.isPersonalBuild());
@@ -548,7 +548,7 @@ public class BuildConfigurationIT extends HudsonTestCase {
 				
 	    		RTCChangeLogParser parser = new RTCChangeLogParser();
 	    		FileReader changeLogReader = new FileReader(changeLogFile);
-	    		RTCChangeLogSet result = (RTCChangeLogSet) parser.parse(null, changeLogReader);
+	    		RTCChangeLogSet result = (RTCChangeLogSet) parser.parse(null, null, changeLogReader);
 	    		
 	    		// verify the result
 	    		int changeCount = result.getComponentChangeCount() +
@@ -666,7 +666,7 @@ public class BuildConfigurationIT extends HudsonTestCase {
 				
 	    		RTCChangeLogParser parser = new RTCChangeLogParser();
 	    		FileReader changeLogReader = new FileReader(changeLogFile);
-	    		RTCChangeLogSet result = (RTCChangeLogSet) parser.parse(null, changeLogReader);
+	    		RTCChangeLogSet result = (RTCChangeLogSet) parser.parse(null, null, changeLogReader);
 	    		
 	    		// verify the result
 	    		int changeCount = result.getComponentChangeCount() +

--- a/com.ibm.team.build.hjplugin/src/test/java/com/ibm/team/build/internal/hjplugin/tests/RTCBuildTaskIT.java
+++ b/com.ibm.team.build.hjplugin/src/test/java/com/ibm/team/build/internal/hjplugin/tests/RTCBuildTaskIT.java
@@ -216,7 +216,7 @@ public class RTCBuildTaskIT extends HudsonTestCase {
 	    		// parse the change report and ensure the expected components are reported.
 	    		RTCChangeLogParser parser = new RTCChangeLogParser();
 	    		FileReader changeLogReader = new FileReader(changeLogFile);
-	    		RTCChangeLogSet result = (RTCChangeLogSet) parser.parse(null, changeLogReader);
+	    		RTCChangeLogSet result = (RTCChangeLogSet) parser.parse(null, null, changeLogReader);
 	    		
 	    		// verify the result
 	    		Assert.assertNotNull(result.getBaselineSetItemId());
@@ -336,7 +336,7 @@ public class RTCBuildTaskIT extends HudsonTestCase {
 	    		// parse the change report and ensure the expected components are reported.
 	    		RTCChangeLogParser parser = new RTCChangeLogParser();
 	    		FileReader changeLogReader = new FileReader(changeLogFile);
-	    		RTCChangeLogSet result = (RTCChangeLogSet) parser.parse(null, changeLogReader);
+	    		RTCChangeLogSet result = (RTCChangeLogSet) parser.parse(null, null, changeLogReader);
 	    		
 	    		// verify the result
 	    		Assert.assertNotNull(result.getBaselineSetItemId());

--- a/com.ibm.team.build.hjplugin/src/test/java/com/ibm/team/build/internal/hjplugin/tests/RTCChangeLogParserTest.java
+++ b/com.ibm.team.build.hjplugin/src/test/java/com/ibm/team/build/internal/hjplugin/tests/RTCChangeLogParserTest.java
@@ -98,7 +98,7 @@ public class RTCChangeLogParserTest extends TestCase {
 				"</changelog>");
 		
 		RTCChangeLogParser parser = new RTCChangeLogParser();
-		RTCChangeLogSet result = (RTCChangeLogSet) parser.parse(null, changeLog);
+		RTCChangeLogSet result = (RTCChangeLogSet) parser.parse(null, null, changeLog);
 		
 		// use the iterator to collect all the items
 		// compare against the other methods that return the categorized items
@@ -192,10 +192,10 @@ public class RTCChangeLogParserTest extends TestCase {
 			} else if (changeSetItemId.equals("_H7VJsUuOEeK5tewUzhIIVw")) {
 				Assert.assertEquals("Change count for " + changeSetItemId, 0, changeSetEntry.getAffectedVersionables().size());
 				String path = changeSetEntry.getAffectedPaths().iterator().next();
-				Assert.assertTrue(path, path.contains("2034") || path.contains("2,034"));
+				Assert.assertTrue(path, path.contains("2034") || path.contains("2,034") || path.contains("2.034"));
 				Assert.assertTrue("Doesn't report back too many changes", changeSetEntry.isTooManyChanges());
 				Assert.assertTrue(changeSetEntry.getTooManyChangesMsg(),
-						changeSetEntry.getTooManyChangesMsg().contains("2034") || path.contains("2,034"));
+						changeSetEntry.getTooManyChangesMsg().contains("2034") || path.contains("2,034") || path.contains("2.034"));
 				Assert.assertNull("Primary work item", changeSetEntry.getWorkItem());
 				Assert.assertEquals("Work item count " + changeSetItemId, 0, changeSetEntry.getAdditionalWorkItems().size());
 				WorkItemDesc workItem = changeSetEntry.getWorkItem();
@@ -219,7 +219,7 @@ public class RTCChangeLogParserTest extends TestCase {
 		URL changeLogURL = getClass().getResource("MissingComponentName.xml");
 		File changeLogFile = new File(changeLogURL.toURI());
 		RTCChangeLogParser parser = new RTCChangeLogParser();
-		RTCChangeLogSet result = (RTCChangeLogSet) parser.parse(null, changeLogFile);
+		RTCChangeLogSet result = (RTCChangeLogSet) parser.parse(null, null, changeLogFile);
 		
 		Assert.assertEquals(1, result.getAffectedComponents().size());
 		Assert.assertEquals(3, result.getChangeSetsAcceptedCount());
@@ -235,7 +235,7 @@ public class RTCChangeLogParserTest extends TestCase {
 		URL changeLogURL = getClass().getResource("DuplicateComponentName.xml");
 		File changeLogFile = new File(changeLogURL.toURI());
 		RTCChangeLogParser parser = new RTCChangeLogParser();
-		RTCChangeLogSet result = (RTCChangeLogSet) parser.parse(null, changeLogFile);
+		RTCChangeLogSet result = (RTCChangeLogSet) parser.parse(null, null, changeLogFile);
 		
 		Assert.assertEquals(2, result.getAffectedComponents().size());
 		Assert.assertEquals(2, result.getChangeSetsAcceptedCount());
@@ -256,7 +256,7 @@ public class RTCChangeLogParserTest extends TestCase {
 				"</changelog>");
 		
 		RTCChangeLogParser parser = new RTCChangeLogParser();
-		RTCChangeLogSet result = (RTCChangeLogSet) parser.parse(null, changeLog);
+		RTCChangeLogSet result = (RTCChangeLogSet) parser.parse(null, null, changeLog);
 		Assert.assertFalse("Expected no change entries", result.iterator().hasNext());
 		Assert.assertTrue("Expected it to be an empty set", result.isEmptySet());
 		Assert.assertEquals(0, result.getAffectedComponents().size());
@@ -267,7 +267,7 @@ public class RTCChangeLogParserTest extends TestCase {
 		URL changeLogURL = getClass().getResource("Defect261133.xml");
 		File changeLogFile = new File(changeLogURL.toURI());
 		RTCChangeLogParser parser = new RTCChangeLogParser();
-		RTCChangeLogSet result = (RTCChangeLogSet) parser.parse(null, changeLogFile);
+		RTCChangeLogSet result = (RTCChangeLogSet) parser.parse(null, null, changeLogFile);
 		
 		Assert.assertEquals("ハローワールド #6", result.getBaselineSetName());
 		Assert.assertEquals(1, result.getAffectedComponents().size());
@@ -290,7 +290,7 @@ public class RTCChangeLogParserTest extends TestCase {
 		URL changeLogURL = getClass().getResource("PersonalBuild.xml");
 		File changeLogFile = new File(changeLogURL.toURI());
 		RTCChangeLogParser parser = new RTCChangeLogParser();
-		RTCChangeLogSet result = (RTCChangeLogSet) parser.parse(null, changeLogFile);
+		RTCChangeLogSet result = (RTCChangeLogSet) parser.parse(null, null, changeLogFile);
 		
 		Assert.assertFalse("Expected no change entries", result.iterator().hasNext());
 		Assert.assertTrue("Expected it to be an empty set", result.isEmptySet());

--- a/com.ibm.team.build.hjplugin/src/test/java/com/ibm/team/build/internal/hjplugin/tests/RTCRepositoryBrowserIT.java
+++ b/com.ibm.team.build.hjplugin/src/test/java/com/ibm/team/build/internal/hjplugin/tests/RTCRepositoryBrowserIT.java
@@ -122,7 +122,7 @@ public class RTCRepositoryBrowserIT  extends HudsonTestCase {
 	 *  a component change and a baseline set.
 	 */
 	private RTCChangeLogSet setupChangeLogSet() {
-		RTCChangeLogSet changeLogSet = new RTCChangeLogSet(null);
+		RTCChangeLogSet changeLogSet = new RTCChangeLogSet(null, null);
 		changeLogSet.setBaselineSetItemId(BASELINE_SET_ITEMID);
 		
 		RTCChangeLogChangeSetEntry.WorkItemDesc workItem = new WorkItemDesc();

--- a/com.ibm.team.build.hjplugin/src/test/java/com/ibm/team/build/internal/hjplugin/tests/RepositoryConnectionIT.java
+++ b/com.ibm.team.build.hjplugin/src/test/java/com/ibm/team/build/internal/hjplugin/tests/RepositoryConnectionIT.java
@@ -173,7 +173,7 @@ public class RepositoryConnectionIT extends HudsonTestCase {
 	    		// parse the change report and ensure the expected components are reported.
 	    		RTCChangeLogParser parser = new RTCChangeLogParser();
 	    		FileReader changeLogReader = new FileReader(changeLogFile);
-	    		RTCChangeLogSet result = (RTCChangeLogSet) parser.parse(null, changeLogReader);
+	    		RTCChangeLogSet result = (RTCChangeLogSet) parser.parse(null, null, changeLogReader);
 	    		
 	    		// verify the result
 	    		Assert.assertNull(result.getBaselineSetItemId());
@@ -291,7 +291,7 @@ public class RepositoryConnectionIT extends HudsonTestCase {
 	    		// parse the change report and ensure the expected components are reported.
 	    		RTCChangeLogParser parser = new RTCChangeLogParser();
 	    		FileReader changeLogReader = new FileReader(changeLogFile);
-	    		RTCChangeLogSet result = (RTCChangeLogSet) parser.parse(null, changeLogReader);
+	    		RTCChangeLogSet result = (RTCChangeLogSet) parser.parse(null, null, changeLogReader);
 	    		
 	    		// verify the result
 	    		Assert.assertNotNull(result.getBaselineSetItemId());
@@ -442,7 +442,7 @@ public class RepositoryConnectionIT extends HudsonTestCase {
 	    		// parse the change report and ensure the expected components are reported.
 	    		RTCChangeLogParser parser = new RTCChangeLogParser();
 	    		FileReader changeLogReader = new FileReader(changeLogFile);
-	    		RTCChangeLogSet result = (RTCChangeLogSet) parser.parse(null, changeLogReader);
+	    		RTCChangeLogSet result = (RTCChangeLogSet) parser.parse(null, null, changeLogReader);
 	    		
 	    		// verify the result
 	    		Assert.assertNotNull(result.getBaselineSetItemId());
@@ -592,7 +592,7 @@ public class RepositoryConnectionIT extends HudsonTestCase {
 	    		// parse the change report and ensure the expected components are reported.
 	    		RTCChangeLogParser parser = new RTCChangeLogParser();
 	    		FileReader changeLogReader = new FileReader(changeLogFile);
-	    		RTCChangeLogSet result = (RTCChangeLogSet) parser.parse(null, changeLogReader);
+	    		RTCChangeLogSet result = (RTCChangeLogSet) parser.parse(null, null, changeLogReader);
 	    		
 	    		// verify the result
 	    		Assert.assertNotNull(result.getBaselineSetItemId());
@@ -843,7 +843,7 @@ public class RepositoryConnectionIT extends HudsonTestCase {
 	    		// parse the change report and ensure the expected components are reported.
 	    		RTCChangeLogParser parser = new RTCChangeLogParser();
 	    		FileReader changeLogReader = new FileReader(changeLogFile);
-	    		RTCChangeLogSet result = (RTCChangeLogSet) parser.parse(null, changeLogReader);
+	    		RTCChangeLogSet result = (RTCChangeLogSet) parser.parse(null, null, changeLogReader);
 	    		
 	    		// verify the result
 	    		Assert.assertNotNull(result.getBaselineSetItemId());
@@ -953,7 +953,7 @@ public class RepositoryConnectionIT extends HudsonTestCase {
 	    		// parse the change report and ensure the expected components are reported.
 	    		RTCChangeLogParser parser = new RTCChangeLogParser();
 	    		FileReader changeLogReader = new FileReader(changeLogFile);
-	    		RTCChangeLogSet result = (RTCChangeLogSet) parser.parse(null, changeLogReader);
+	    		RTCChangeLogSet result = (RTCChangeLogSet) parser.parse(null, null, changeLogReader);
 	    		
 	    		// verify the result
 	    		Assert.assertNotNull(result.getBaselineSetItemId());
@@ -1060,7 +1060,7 @@ public class RepositoryConnectionIT extends HudsonTestCase {
 	    		// parse the change report and ensure the expected components are reported.
 	    		RTCChangeLogParser parser = new RTCChangeLogParser();
 	    		FileReader changeLogReader = new FileReader(changeLogFile);
-	    		RTCChangeLogSet result = (RTCChangeLogSet) parser.parse(null, changeLogReader);
+	    		RTCChangeLogSet result = (RTCChangeLogSet) parser.parse(null, null, changeLogReader);
 	    		
 	    		// verify the result
 	    		Assert.assertNotNull(result.getBaselineSetItemId());
@@ -1165,7 +1165,7 @@ public class RepositoryConnectionIT extends HudsonTestCase {
 	    		// parse the change report and ensure the expected components are reported.
 	    		RTCChangeLogParser parser = new RTCChangeLogParser();
 	    		FileReader changeLogReader = new FileReader(changeLogFile);
-	    		RTCChangeLogSet result = (RTCChangeLogSet) parser.parse(null, changeLogReader);
+	    		RTCChangeLogSet result = (RTCChangeLogSet) parser.parse(null, null, changeLogReader);
 	    		
 	    		// verify the result
 	    		Assert.assertNotNull(result.getBaselineSetItemId());
@@ -1325,7 +1325,7 @@ public class RepositoryConnectionIT extends HudsonTestCase {
 	    		// parse the change report and ensure the expected components are reported.
 	    		RTCChangeLogParser parser = new RTCChangeLogParser();
 	    		FileReader changeLogReader = new FileReader(changeLogFile);
-	    		RTCChangeLogSet result = (RTCChangeLogSet) parser.parse(null, changeLogReader);
+	    		RTCChangeLogSet result = (RTCChangeLogSet) parser.parse(null, null, changeLogReader);
 	    		
 	    		// verify the result
 	    		Assert.assertNotNull(result.getBaselineSetItemId());
@@ -1668,7 +1668,7 @@ public class RepositoryConnectionIT extends HudsonTestCase {
 	    		// parse the change report and ensure the expected components are reported.
 	    		RTCChangeLogParser parser = new RTCChangeLogParser();
 	    		FileReader changeLogReader = new FileReader(changeLogFile);
-	    		RTCChangeLogSet result = (RTCChangeLogSet) parser.parse(null, changeLogReader);
+	    		RTCChangeLogSet result = (RTCChangeLogSet) parser.parse(null, null, changeLogReader);
 	    		
 	    		// verify the result
 	    		Assert.assertNotNull(result.getBaselineSetItemId());


### PR DESCRIPTION
Base Jenkins required version is upgraded to 1.580.1 that version
includes the changes required by the Workflow plugin, i.e. using Job
instead of AbstractBuild. For using with workflow plugin one should use
a more recent Jenkins version: latest or LTS 1.596.x.

This allows for using the general SCM support in Jenkins workflow such as:

    import com.ibm.team.build.internal.hjplugin.RTCScm;
    import com.ibm.team.build.internal.hjplugin.RTCScm.BuildType;
   
    checkout changelog: true, poll: true, scm: [$class: 'RTCScm', avoidUsingToolkit: false, buildTool: '...', buildType: new BuildType(RTCScm.BUILD_DEFINITION_TYPE, '...', ""), credentialsId: '...', overrideGlobal: false, serverURI: '...', timeout: 480]