### PR TITLE
Adding Load Rules input

### DIFF
--- a/com.ibm.team.build.hjplugin/src/main/java/com/ibm/team/build/internal/hjplugin/loadrule/LoadRuleEntry.java
+++ b/com.ibm.team.build.hjplugin/src/main/java/com/ibm/team/build/internal/hjplugin/loadrule/LoadRuleEntry.java
@@ -1,0 +1,110 @@
+package com.ibm.team.build.internal.hjplugin.loadrule;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+
+import jenkins.model.Jenkins;
+import hudson.DescriptorExtensionList;
+import hudson.Extension;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+import hudson.util.FormValidation;
+
+/**
+ * Represents an entry of a Load Rule file. Each entry is a pair of Component
+ * name or UUID and the filepath of the Load Rule file within.
+ */
+public class LoadRuleEntry extends AbstractDescribableImpl<LoadRuleEntry> {
+
+    /**
+     * Component Name or UUID
+     */
+    protected String componentUUID = null;
+
+    /**
+     * Path of the Load Rule file within the Component
+     */
+    protected String loadRulesFilepath = null;
+    
+    /**
+     * @param componentUUID Component Name or UUID
+     * @param loadRulesFilepath Path of the Load Rule file within the Component
+     */
+    @DataBoundConstructor
+    public LoadRuleEntry(String componentUUID, String loadRulesFilepath) {
+	super();
+	this.componentUUID = componentUUID;
+	this.loadRulesFilepath = loadRulesFilepath;
+    }
+
+    /**
+     * @return the componentUUID
+     */
+    public String getComponentUUID() {
+        return componentUUID;
+    }
+
+    /**
+     * @param componentUUID the componentUUID to set
+     */
+    public void setComponentUUID(String componentUUID) {
+        this.componentUUID = componentUUID;
+    }
+
+    /**
+     * @return the loadRulesFilepath
+     */
+    public String getLoadRulesFilepath() {
+        return loadRulesFilepath;
+    }
+
+    /**
+     * @param loadRulesFilepath the loadRulesFilepath to set
+     */
+    public void setLoadRulesFilepath(String loadRulesFilepath) {
+        this.loadRulesFilepath = loadRulesFilepath;
+    }
+    
+    /**
+     * Load Rule Entry descriptor. Inner class of a descriptor class. Specifies and
+     * validate the content exhibited in the Jenkins interface.
+     */
+    @Extension
+    public static class LoadRuleEntryDescriptor extends Descriptor<LoadRuleEntry> {
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public String getDisplayName() {
+    		// TODO Auto-generated method stub
+    		return "Load Rule Entry";
+        }
+
+        /**
+         * @return List of all available descriptors for LoadRuleEntry.
+         */
+        public static DescriptorExtensionList<LoadRuleEntry, LoadRuleEntryDescriptor> all() {
+    		return Jenkins.getInstance().getDescriptorList(LoadRuleEntry.class);
+        }
+        
+        /**
+         * Invoked from Jenkins to validate field.
+         * @param componentUUID Component name or UUID
+         * @return Validation message.
+         */
+        public FormValidation doCheckComponentUUID(@QueryParameter String componentUUID) {
+    		return FormValidation.validateRequired(componentUUID);
+        }
+        
+        /**
+         * Invoked from Jenkins to validate field.
+         * @param loadRulesFilepath Path of the Load Rule file within the Component
+         * @return Validation message.
+         */
+        public FormValidation doCheckLoadRulesFilepath(@QueryParameter String loadRulesFilepath) {
+    		return FormValidation.validateRequired(loadRulesFilepath);
+        }
+    }
+
+}

--- a/com.ibm.team.build.hjplugin/src/main/java/com/ibm/team/build/internal/hjplugin/loadrule/LoadRuleUtils.java
+++ b/com.ibm.team.build.hjplugin/src/main/java/com/ibm/team/build/internal/hjplugin/loadrule/LoadRuleUtils.java
@@ -1,0 +1,58 @@
+package com.ibm.team.build.internal.hjplugin.loadrule;
+
+import java.util.List;
+
+/**
+ * Utilities to handle the format and validation of Load Rules.
+ * 
+ */
+public class LoadRuleUtils {
+
+    /**
+     * Generates a load rule JSON string from a list of load rule entries.
+     * The return format is as follow:
+     * 
+     * {
+     *   "loadRules":[
+     *       {
+     *          "componentName":"JUnit",
+     * 		"filePath":"JUnit Project/junit-project.loadrule"
+     *       },
+     *       {
+     *          "componentName":"Releng",
+     *          "filePath":"Releng Project/releng-project.loadrule"
+     *       }
+     *   ]
+     * }
+     * 
+     * @param loadRuleEntries List of LoadRuleEntry
+     * @return Load Rule in JSON format
+     */
+    public static String generateLoadRulesJson(
+	    List<LoadRuleEntry> loadRuleEntries) {
+
+	final String JSON_LOADRULES = "{\"loadRules\":[%s]}";
+	final String JSON_LOADRULE_ENTRY = "{\"componentName\":\"%s\", \"filePath\":\"%s\"},";
+
+	// There are specific libraries to create JSON. But since our Load Rules
+	// JSON is very simple, it can be handle with StringBuilder and a simple
+	// logic.
+
+	StringBuilder loadRuleEntriesBuilder = new StringBuilder();
+	for (LoadRuleEntry loadRuleEntry : loadRuleEntries) {
+	  
+	  String componentUUID = loadRuleEntry.componentUUID;
+      String loadRulesFilepath = loadRuleEntry.loadRulesFilepath.replace("\\", "/");
+      
+      loadRuleEntriesBuilder.append(String.format(JSON_LOADRULE_ENTRY,
+		    componentUUID,
+		    loadRulesFilepath));
+	}
+	
+	// Cheapest way to remove last comma without relying on additional libs 
+	loadRuleEntriesBuilder.deleteCharAt(loadRuleEntriesBuilder.length()-1);
+
+	return String.format(JSON_LOADRULES, loadRuleEntriesBuilder.toString());
+    }
+
+}

--- a/com.ibm.team.build.hjplugin/src/main/resources/com/ibm/team/build/internal/hjplugin/RTCScm/config-loadoptions.jelly
+++ b/com.ibm.team.build.hjplugin/src/main/resources/com/ibm/team/build/internal/hjplugin/RTCScm/config-loadoptions.jelly
@@ -11,4 +11,10 @@
 
         <!-- Create folders for components -->
         <f:optionalBlock name="createFoldersForComponents" title="${%load.createFoldersForComponents}" field="createFoldersForComponents" checked="${instance.createFoldersForComponents}" inline="true" />
+        <!-- Use Load Rules -->
+        <f:optionalBlock name="useLoadRules" title="${%load.useLoadRules}" field="useLoadRules" checked="${instance.useLoadRules}" inline="true">
+        <f:entry>
+                <f:hetero-list name="loadRules" items="${instance.loadRules}" descriptors="${descriptor.getLoadRuleEntryDescriptors()}" hasHeader="true" />
+            </f:entry>
+        </f:optionalBlock>
 </j:jelly>

--- a/com.ibm.team.build.hjplugin/src/main/resources/com/ibm/team/build/internal/hjplugin/RTCScm/config-loadoptions.properties
+++ b/com.ibm.team.build.hjplugin/src/main/resources/com/ibm/team/build/internal/hjplugin/RTCScm/config-loadoptions.properties
@@ -18,6 +18,7 @@ loadDirectory.title=Load directory
 loadDirectory.clearDirectory=Delete directory before loading
 load.createFoldersForComponents=Create folders for components
 componentsToExclude.title=Components to exclude
+load.useLoadRules=Use Load Rules
 loadRules.title=Load rules
 validate.title=Validate
 validate.progress=Validating...

--- a/com.ibm.team.build.hjplugin/src/main/resources/com/ibm/team/build/internal/hjplugin/loadrule/LoadRuleEntry/config.jelly
+++ b/com.ibm.team.build.hjplugin/src/main/resources/com/ibm/team/build/internal/hjplugin/loadrule/LoadRuleEntry/config.jelly
@@ -1,0 +1,11 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    
+    <f:entry title="${%componentUUID.title}" field="componentUUID">
+        <f:textbox name="componentUUID"/>
+    </f:entry>
+    <f:entry title="${%loadRulesFilepath.title}" field="loadRulesFilepath">
+        <f:textbox name="loadRulesFilepath"/>
+    </f:entry>
+    
+</j:jelly>

--- a/com.ibm.team.build.hjplugin/src/main/resources/com/ibm/team/build/internal/hjplugin/loadrule/LoadRuleEntry/config.properties
+++ b/com.ibm.team.build.hjplugin/src/main/resources/com/ibm/team/build/internal/hjplugin/loadrule/LoadRuleEntry/config.properties
@@ -1,0 +1,2 @@
+componentUUID.title=Component Name or UUID
+loadRulesFilepath.title=Load Rule file location


### PR DESCRIPTION
**Adding Load Rule input fields to Team Concert plugin.**
This implementation allows loading with Load Rules even when using other input source than _Build Definition_.

More info: https://jazz.net/jazz/web/projects/Rational%20Team%20Concert#action=com.ibm.team.workitem.viewWorkItem&id=388719

Changes are subject to IBM approval (of course!) and are merged in their internal repository instead of GitHub.